### PR TITLE
Connection validation for consumption-only templates

### DIFF
--- a/patch_template_variables.js
+++ b/patch_template_variables.js
@@ -166,14 +166,16 @@ const updateConnections = async (manifest, workflow) => {
       connection.connectorId = sanitizeConnectorId(connection.connectorId);
     }
 
-    if (!name.endsWith(workflowSuffix)) {
+    if (name.endsWith(workflowSuffix)) {
+      const oldName = name?.split(workflowSuffix)?.[0];
+      workflow = workflow.replaceAll(`"${oldName}"`, `"${name}"`);
+      workflow = workflow.replaceAll(`'${oldName}'`, `'${name}'`);
+    } else {
       const newName = `${name}${workflowSuffix}`;
-
       workflow = workflow.replaceAll(`"${name}"`, `"${newName}"`);
+      workflow = workflow.replaceAll(`'${name}'`, `'${newName}'`);
       updatedConnections[newName] = connection;
       delete updatedConnections[name];
-    } else {
-      updatedConnections[name] = connection;
     }
   }
 

--- a/validate_templates.ts
+++ b/validate_templates.ts
@@ -200,7 +200,14 @@ const validateManifest = (folderName: string, isMultiWorkflow, manifestFile) => 
             }
         }
 
-        const parameterConnectionsMatches = workflowFileString.matchAll(/@parameters\('\$connections'\)\['([^']+)'\]\['connectionId'\]/g);
+        const parameterConnectionsMatches = [...workflowFileString.matchAll(/@parameters\('\$connections'\)\['([^']+)'\]\['connectionId'\]/g)];
+
+        // If skus is not defined, it supports both
+        if (parameterConnectionsMatches?.length && (isMultiWorkflow || (manifestFile?.skus?.includes("standard") ?? true))) {
+            console.error(`Workflow "${folderName}" Failed Validation: @parameters('$connections') is invalid for standard workflows. Either remove the @parameters('$connections') or set the sku to "consumption" in manifest.json`);
+            throw '';
+        }
+
         for (const match of parameterConnectionsMatches) {
             if (!connectionNames.includes(match[1])) {
                 console.error(`Workflow "${folderName}" Failed Validation: @parameters('$connections') "${match[1]}" not found in manifest.json. Hint: Make sure the connection name is in the format <connectionName>_#workflowname#`);

--- a/validate_templates.ts
+++ b/validate_templates.ts
@@ -173,18 +173,17 @@ const validateManifest = (folderName: string, isMultiWorkflow, manifestFile) => 
         //     throw '';
         // }
 
-        // const parameterNames =  manifestFile.parameters.map(parameter => parameter.name);
+        const parameterNames =  manifestFile.parameters.map(parameter => parameter.name);
         const connectionNames = Object.keys(manifestFile.connections);
     
-        // const parameterMatches = workflowFileString.matchAll(/@parameters\('\s*([^"]+)\s*'\)/g);
-        
-        // for (const match of parameterMatches) {
-        //     if (!parameterNames.includes(match[1])) {
-        //         console.error(`Workflow "${folderName}" Failed Validation: parameter "${match[1]}" not found in manifest.json. Hint: Make sure the parameter name is in the format <parameterName>_#workflowname#`);
-        //         throw '';
-        //     }
-        // }
-     
+        const parameterMatches = workflowFileString.matchAll(/@parameters\('\s*(?!\$connections)([^"]+)\s*'\)/g);
+        for (const match of parameterMatches) {
+            if (!parameterNames.includes(match[1])) {
+                console.error(`Workflow "${folderName}" Failed Validation: parameter "${match[1]}" not found in manifest.json. Hint: Make sure the parameter name is in the format <parameterName>_#workflowname#`);
+                throw '';
+            }
+        }
+
         const connectionReferenceMatches = workflowFileString.matchAll(/"connection":\s*\{\s*"referenceName":\s*"([^"]+)"\}/g);
         for (const match of connectionReferenceMatches) {
             if (!connectionNames.includes(match[1])) {
@@ -197,6 +196,14 @@ const validateManifest = (folderName: string, isMultiWorkflow, manifestFile) => 
         for (const match of connectionNameMatches) {
             if (!connectionNames.includes(match[1])) {
                 console.error(`Workflow "${folderName}" Failed Validation: connection used in "connectionName": "${match[1]}" not found in manifest.json. Hint: Make sure the connection name is in the format <connectionName>_#workflowname#`);
+                throw '';
+            }
+        }
+
+        const parameterConnectionsMatches = workflowFileString.matchAll(/@parameters\('\$connections'\)\['([^']+)'\]\['connectionId'\]/g);
+        for (const match of parameterConnectionsMatches) {
+            if (!connectionNames.includes(match[1])) {
+                console.error(`Workflow "${folderName}" Failed Validation: @parameters('$connections') "${match[1]}" not found in manifest.json. Hint: Make sure the connection name is in the format <connectionName>_#workflowname#`);
                 throw '';
             }
         }


### PR DESCRIPTION
- Support adding workflow suffix in workflow.json for connections that already has suffix in manifest.json
- Ensures `@parameters('$connections')...` is only present for consumption templates
- Supports connection existence/suffix checks for `@parameters('$connections')...`