### PR TITLE
Disabling `manifest.json` registration check + small typo fix 

### DIFF
--- a/agentservicemanifest.json
+++ b/agentservicemanifest.json
@@ -1,8 +1,6 @@
 [
     "tool-send-email-outlook",
     "tool-get-weather-msn",
-    "tool-post-message-teams",
-    "tool-post-adaptive-card-teams",
     "tool-get-rows-dataverse",
     "tool-get-rows-sql",
     "tool-execute-query-sql",

--- a/manifest.json
+++ b/manifest.json
@@ -51,8 +51,6 @@
     "vectorize-servicebus-aisearch-schedule",
     "tool-send-email-outlook",
     "tool-get-weather-msn",
-    "tool-post-message-teams",
-    "tool-post-adaptive-card-teams",
     "tool-get-rows-dataverse",
     "tool-get-rows-sql",
     "tool-execute-query-sql",

--- a/tool-get-weather-msn/default/manifest.json
+++ b/tool-get-weather-msn/default/manifest.json
@@ -1,6 +1,6 @@
 {
     "id": "default",
-    "title": "Get Weather forecase for today via MSN Weather",
+    "title": "Get Weather forecast for today via MSN Weather",
     "summary": "Get the weather forecast for today using MSN Weather API.",
     "description": "This workflow retrieves the weather forecast for today using the MSN Weather API. It is designed to be triggered by an HTTP request and to provide weather information.",
     "artifacts": [

--- a/tool-get-weather-msn/manifest.json
+++ b/tool-get-weather-msn/manifest.json
@@ -1,6 +1,6 @@
 {
     "id": "tool-get-weather-msn",
-    "title": "Get Weather forecase for today via MSN Weather",
+    "title": "Get Weather forecast for today via MSN Weather",
     "summary": "Get the weather forecast for today using MSN Weather API.",
     "description": "This workflow retrieves the weather forecast for today using the MSN Weather API. It is designed to be triggered by an HTTP request and to provide weather information.",
     "skus": [

--- a/validate_templates.ts
+++ b/validate_templates.ts
@@ -294,7 +294,7 @@ if (registeredNotExisting.length) {
 const templatesNotRegistered = allManifestDirectories.filter(item => !manifestNamesList.includes(item));
 if (templatesNotRegistered.length) {
     console.error(`Template(s) ${JSON.stringify(templatesNotRegistered)} found in the repository are not registered in manifest.json.`);
-    throw '';
+    // throw '';    // Disabling error throwing, considering purposefully non-registered templates
 }
 
 for (const folderName of manifestNamesList) {


### PR DESCRIPTION
- Disabling manifest.json registration check
- Excluding two templates with issues (https://github.com/Azure/LogicAppsTemplates/pull/98)
- Small typo fix (https://github.com/Azure/LogicAppsTemplates/pull/99)

Cherry-pick of https://github.com/Azure/LogicAppsTemplates/pull/100